### PR TITLE
Fix ID and endless re-queuing bugs

### DIFF
--- a/Community/Tdarr_Plugin_z0ab_TheRealShadoh_FFmpeg_Subs_H264_Medium.js
+++ b/Community/Tdarr_Plugin_z0ab_TheRealShadoh_FFmpeg_Subs_H264_Medium.js
@@ -4,7 +4,7 @@
 function details() {
 
   return {
-    id: "Tdarr_Plugin_z0ab_TheRealShadoh_FFmpeg_Subs_H264_Medium.js",
+    id: "Tdarr_Plugin_z0ab_TheRealShadoh_FFmpeg_Subs_H264_Medium",
     Name: "TheRealShadoh FFmpeg Subs Medium, video MP4, audio AAC, keep subs. ",
     Type: "Video",
     Description: `[Contains built-in filter] This plugin transcodes into H264 using FFmpeg's 'Medium' preset if the file is not in H264 already. It maintains all subtitles. It removes metadata (if a title exists), and maintains all audio tracks. The output container is MP4. \n\n

--- a/Community/Tdarr_Plugin_z0ab_TheRealShadoh_FFmpeg_Subs_H264_Medium.js
+++ b/Community/Tdarr_Plugin_z0ab_TheRealShadoh_FFmpeg_Subs_H264_Medium.js
@@ -142,7 +142,6 @@ function plugin(file) {
 
       response.infoLog += "☒File has subs \n"
       response.preset = ', -map 0:v -map 0:s? -map 0:a -c:v copy -c:a copy -c:s mov_text'
-      response.reQueueAfter = true;
       response.processFile = true;
       response.FFmpegMode = true
       return response

--- a/Community/Tdarr_Plugin_z1ab_TheRealShadoh_FFmpeg_Subs_H264_Fast.js
+++ b/Community/Tdarr_Plugin_z1ab_TheRealShadoh_FFmpeg_Subs_H264_Fast.js
@@ -141,7 +141,6 @@ function plugin(file) {
 
       response.infoLog += "☒File has subs \n"
       response.preset = ', -map 0:v -map 0:s? -map 0:a -c:v copy -c:a copy -c:s mov_text'
-      response.reQueueAfter = true;
       response.processFile = true;
       response.FFmpegMode = true
       return response

--- a/Community/Tdarr_Plugin_z1ab_TheRealShadoh_FFmpeg_Subs_H264_Fast.js
+++ b/Community/Tdarr_Plugin_z1ab_TheRealShadoh_FFmpeg_Subs_H264_Fast.js
@@ -4,7 +4,7 @@
 function details() {
 
   return {
-    id: "Tdarr_Plugin_z1ab_TheRealShadoh_FFmpeg_Subs_H264_Fast.js",
+    id: "Tdarr_Plugin_z1ab_TheRealShadoh_FFmpeg_Subs_H264_Fast",
     Name: "TheRealShadoh FFmpeg Subs Fast, video MP4, audio AAC, keep subs. ",
     Type: "Video",
     Description: `[Contains built-in filter] This plugin transcodes into H264 using FFmpeg's 'Fast' preset if the file is not in H264 already. It maintains all subtitles. It removes metadata (if a title exists), and maintains all audio tracks. The output container is MP4. \n\n

--- a/Community/Tdarr_Plugin_z2ab_TheRealShadoh_FFmpeg_Subs_H264_Slow.js
+++ b/Community/Tdarr_Plugin_z2ab_TheRealShadoh_FFmpeg_Subs_H264_Slow.js
@@ -4,7 +4,7 @@
 function details() {
 
   return {
-    id: "Tdarr_Plugin_z2ab_TheRealShadoh_FFmpeg_Subs_H264_Slow.js",
+    id: "Tdarr_Plugin_z2ab_TheRealShadoh_FFmpeg_Subs_H264_Slow",
     Name: "TheRealShadoh FFmpeg Subs Slow, video MP4, audio AAC, keep subs. ",
     Type: "Video",
     Description: `[Contains built-in filter] This plugin transcodes into H264 using FFmpeg's 'Slow' preset if the file is not in H264 already. It maintains all subtitles. It removes metadata (if a title exists), and maintains all audio tracks. The output container is MP4. \n\n

--- a/Community/Tdarr_Plugin_z2ab_TheRealShadoh_FFmpeg_Subs_H264_Slow.js
+++ b/Community/Tdarr_Plugin_z2ab_TheRealShadoh_FFmpeg_Subs_H264_Slow.js
@@ -142,7 +142,6 @@ function plugin(file) {
 
       response.infoLog += "☒File has subs \n"
       response.preset = ', -map 0:v -map 0:s? -map 0:a -c:v copy -c:a copy -c:s mov_text'
-      response.reQueueAfter = true;
       response.processFile = true;
       response.FFmpegMode = true
       return response

--- a/Community/Tdarr_Plugin_z3ab_TheRealShadoh_FFmpeg_Subs_H264_VeryFast.js
+++ b/Community/Tdarr_Plugin_z3ab_TheRealShadoh_FFmpeg_Subs_H264_VeryFast.js
@@ -4,7 +4,7 @@
 function details() {
 
   return {
-    id: "Tdarr_Plugin_z3ab_TheRealShadoh_FFmpeg_Subs_H264_VeryFast.js",
+    id: "Tdarr_Plugin_z3ab_TheRealShadoh_FFmpeg_Subs_H264_VeryFast",
     Name: "TheRealShadoh FFmpeg Subs VeryFast, video MP4, audio AAC, keep subs. ",
     Type: "Video",
     Description: `[Contains built-in filter] This plugin transcodes into H264 using FFmpeg's 'VeryFast' preset if the file is not in H264 already. It maintains all subtitles. It removes metadata (if a title exists), and maintains all audio tracks. The output container is MP4. \n\n

--- a/Community/Tdarr_Plugin_z3ab_TheRealShadoh_FFmpeg_Subs_H264_VeryFast.js
+++ b/Community/Tdarr_Plugin_z3ab_TheRealShadoh_FFmpeg_Subs_H264_VeryFast.js
@@ -142,7 +142,6 @@ function plugin(file) {
 
       response.infoLog += "☒File has subs \n"
       response.preset = ', -map 0:v -map 0:s? -map 0:a -c:v copy -c:a copy -c:s mov_text'
-      response.reQueueAfter = true;
       response.processFile = true;
       response.FFmpegMode = true
       return response


### PR DESCRIPTION
It's been found that the `Copy id` button doesn't work for these plugins as `.js` is included in the id field

It's also been found that videos with subs will be endlessly re-queued due to the  `response.reQueueAfter = true;` statement in the final block of these plugins 

If you'd rather I opened this against https://github.com/HaveAGitGat/Tdarr_Plugins just let me know :+1: 